### PR TITLE
Use chromium --headless + Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+js/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,16 @@ RUN apt-get update && apt-get install -y \
   npm \
   nodejs \
   chromium-browser \
-&& rm -rf /varlib/apt-lists/*
+&& rm -rf /var/lib/apt-lists/*
 
 COPY js /zbrowse
+COPY zbrowse.sh /zbrowse
 
 WORKDIR /zbrowse
 
+RUN chmod +x zbrowse.sh
+
 RUN npm install 
 
-ENTRYPOINT ["nodejs", "index.js"]
+ENTRYPOINT ["/zbrowse/zbrowse.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu
+RUN apt-get update && apt-get install -y \
+  npm \
+  nodejs \
+  chromium-browser \
+&& rm -rf /varlib/apt-lists/*
+
+COPY js /zbrowse
+
+WORKDIR /zbrowse
+
+RUN npm install 
+
+ENTRYPOINT ["nodejs", "index.js"]
+

--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ This is a basic example of using ZBrowse to connect to google.
 ```
 node index.js ~/src/out/Headless/headless_shell 9222 https://www.google.com
 ```
+
+## Docker usage
+
+### Build image
+
+```
+docker build -t zbrowse .
+```
+
+### Run
+
+```
+docker run --rm zbrowse <url>
+```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,17 @@ node index.js <path_to_headless_shell> <headless_connect_port> <URL>
 ```
 node index.js ~/src/out/Headless/headless_shell 9222 https://www.google.com
 ```
+
+## Docker usage
+
+### Build image
+
+```
+docker build -t zbrowse .
+```
+
+### Run
+
+```
+docker run --rm zbrowse <url>
+```

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ date build of headless Chromium is you are experiencing trouble.
 
 ## Requirements
 NodeJS 6+
-headless_shell (or equivalent headless enabled build from Google, https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md)
+chromium-browser version that supports the --headless option
 
 ## Usage
-This tool will spawn a headless_shell instance and connect on the port provided in 
+This tool will spawn a headless Chromium and connect on the port provided in 
 the input.
 
 Before using the tool, be sure to do an
@@ -25,10 +25,10 @@ to get all the relevant node packages.
 
 ```
 cd js
-node index.js <path_to_headless_shell> <headless_connect_port> <URL>
+node index.js <URL>
 ```
 
 ## Example
 ```
-node index.js ~/src/out/Headless/headless_shell 9222 https://www.google.com
+node index.js https://www.google.com
 ```

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Changes in headless Chromium can break functionality with certain sites.
 ## Requirements
 
 *  NodeJS 6+
+*  chromium-browser version that supports the --headless option
 *  headless_shell ([or equivalent headless enabled build from Google](https://chromium.googlesource.com/chromium/src/+/master/headless/README.md "Headless Chromium README"))
 
 ## Getting Started
 
 ZBrowse will spawn a headless_shell instance of Chromium and uses the [DevTools protocol](https://chromedevtools.github.io/devtools-protocol/ "Chrome DevTools Protocol") to instrument, inspect, debug and profile websites.
-
 
 ### Setup
 
@@ -33,7 +33,7 @@ npm install
 
 ```
 cd js
-node index.js <path_to_headless_shell> <headless_connect_port> <URL>
+node index.js <URL>
 ```
 
 ## Example
@@ -41,7 +41,7 @@ node index.js <path_to_headless_shell> <headless_connect_port> <URL>
 This is a basic example of using ZBrowse to connect to google.
 
 ```
-node index.js ~/src/out/Headless/headless_shell 9222 https://www.google.com
+node index.js https://www.google.com
 ```
 
 ## Docker usage

--- a/js/index.js
+++ b/js/index.js
@@ -20,8 +20,13 @@ var debuggingPort = 9222;
 var url = process.argv[2];
 
 /*Start headless process*/
-var headless = spawn(headlessPath, ["--headless", "--disable-gpu",
+var headless = spawn(headlessPath, ["--headless", "--disable-gpu", "--no-sandbox",
     '--remote-debugging-port='+debuggingPort]);
+
+headless.on('error', (err) => {
+  console.error(`Failed to start headless process: ${err}`);
+});
+
 
 var redirects = new Map();
 var responses = new Map();
@@ -137,5 +142,8 @@ function connect() {
     getChromeInstance().then(instance => {
         enableInstanceProperties(instance);
         setTimeout(getResourceTree.bind(null, instance), 25000);
+    }, (error) => {
+      console.error("Error connecting:");
+      console.error(error);
     });
 }

--- a/js/index.js
+++ b/js/index.js
@@ -15,7 +15,7 @@ if (process.argv.length != 3) {
     process.exit(-1);     
 }
 
-var headlessPath = "/usr/bin/chromium-browser";
+var headlessPath = "chromium-browser";
 var debuggingPort = 9222;
 var url = process.argv[2];
 

--- a/js/index.js
+++ b/js/index.js
@@ -10,17 +10,17 @@ var queue = require('./util/queue.js')
 var fs = require('fs')
 var url = require('url')
 
-if (process.argv.length != 5) {
-    console.error('Correct usage: node index.js <headlessPath> <debuggingPort> <url>');
+if (process.argv.length != 3) {
+    console.error('Correct usage: node index.js <url>');
     process.exit(-1);     
 }
 
-var headlessPath = process.argv[2];
-var debuggingPort = process.argv[3];
-var url = process.argv[4];
+var headlessPath = "/usr/bin/chromium-browser";
+var debuggingPort = 9222;
+var url = process.argv[2];
 
 /*Start headless process*/
-var headless = spawn(headlessPath, [
+var headless = spawn(headlessPath, ["--headless", "--disable-gpu",
     '--remote-debugging-port='+debuggingPort]);
 
 var redirects = new Map();

--- a/zbrowse.sh
+++ b/zbrowse.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+nodejs index.js $@ > /tmp/output.js
+cat /tmp/output.js

--- a/zbrowse.sh
+++ b/zbrowse.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-nodejs index.js $@ > /tmp/output.js
+nodejs js/index.js $@ > /tmp/output.js
 cat /tmp/output.js


### PR DESCRIPTION
This PR does two main things: it uses chromium with the --headless switch instead of using a build of headless shell, and it supports docker. A few additional changes are made:

- The usage is simplified, specifying only the URL on the command line. Port 9222 is always used, the chromium-browser is assumed to be in the `$PATH`.
- A few error checks are added to the index.js script
- The browser is run with the `--no-sandbox` switch; this is because otherwise the docker container would need a SYS_ADMIN capability. I *think* this is fine in the current usage of the browser since there are no tabs to isolate from each other, but it's probably worth thinking about.
- It appears that console.log() will truncate the JSON output after some number of bytes _unless_ the output is redirected to a file. This led to the creation of the `zbrowse.sh` script used in the Dockerfile. 